### PR TITLE
한 유저의 챌린지 목록 가져오는 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,17 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	runtimeOnly 'mysql:mysql-connector-java'
+	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '3.0.4'}
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'mysql:mysql-connector-java:8.0.32'
+}
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/whyranoid/walkie/api/ChallengeApi.java
+++ b/src/main/java/com/whyranoid/walkie/api/ChallengeApi.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,8 +20,9 @@ public class ChallengeApi {
     HttpHeaders httpHeaders = new HttpHeaders();
     private final ChallengeService challengeService;
 
-    @PostMapping("/newChallenges")
+    @GetMapping("/newChallenges")
     public ResponseEntity getChallenges(@RequestParam("userId") Long userId) {
+        // 본인 정보를 가져오는 로직이 필요
         List<Challenge> newChallenges = challengeService.getChallenges(userId, 'N');
         return new ResponseEntity<>(newChallenges, httpHeaders, HttpStatus.OK);
     }

--- a/src/main/java/com/whyranoid/walkie/api/ChallengeApi.java
+++ b/src/main/java/com/whyranoid/walkie/api/ChallengeApi.java
@@ -1,0 +1,28 @@
+package com.whyranoid.walkie.api;
+
+import com.whyranoid.walkie.domain.Challenge;
+import com.whyranoid.walkie.service.ChallengeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenge")
+public class ChallengeApi {
+    HttpHeaders httpHeaders = new HttpHeaders();
+    private final ChallengeService challengeService;
+
+    @PostMapping("/newChallenges")
+    public ResponseEntity getChallenges(@RequestParam("userId") Long userId) {
+        List<Challenge> newChallenges = challengeService.getChallenges(userId, 'N');
+        return new ResponseEntity<>(newChallenges, httpHeaders, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/whyranoid/walkie/controller/DummyController.java
+++ b/src/main/java/com/whyranoid/walkie/controller/DummyController.java
@@ -1,0 +1,16 @@
+package com.whyranoid.walkie.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// @Controller와 @ResponseBody가 합쳐진 어노테이션으로 주 용도는 Json 형태로 객체 데이터를 반환한다.
+@RestController
+@RequiredArgsConstructor
+public class DummyController {
+
+    @GetMapping("/")
+    public String dummyController() {
+        return "전현수 주용한 바보";
+    }
+}

--- a/src/main/java/com/whyranoid/walkie/dto/ChallengeDto.java
+++ b/src/main/java/com/whyranoid/walkie/dto/ChallengeDto.java
@@ -1,0 +1,17 @@
+package com.whyranoid.walkie.dto;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChallengeDto {
+    Long challengeId;
+
+    char category;
+
+    String badgeImg;
+    String challengeImg;
+    String name;
+    String content;
+}

--- a/src/main/java/com/whyranoid/walkie/repository/ChallengeRepository.java
+++ b/src/main/java/com/whyranoid/walkie/repository/ChallengeRepository.java
@@ -1,0 +1,23 @@
+package com.whyranoid.walkie.repository;
+
+import com.whyranoid.walkie.domain.Challenge;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ChallengeRepository {
+
+    private final EntityManager em;
+
+    public List<Challenge> getChallenges(Long userId) {
+        List<Challenge> challenges = em.createQuery("select c from Challenge c join ChallengeStatus s on c.challengeId=s.challenge.challengeId where s.walkie.userId = :userId")
+                .setParameter("userId", userId)
+                .getResultList();
+
+        return challenges;
+    }
+}

--- a/src/main/java/com/whyranoid/walkie/repository/ChallengeRepository.java
+++ b/src/main/java/com/whyranoid/walkie/repository/ChallengeRepository.java
@@ -14,7 +14,8 @@ public class ChallengeRepository {
     private final EntityManager em;
 
     public List<Challenge> getChallenges(Long userId) {
-        List<Challenge> challenges = em.createQuery("select c from Challenge c join ChallengeStatus s on c.challengeId=s.challenge.challengeId where s.walkie.userId = :userId")
+        List<Challenge> challenges = em.createQuery("select c from Challenge c left join ChallengeStatus s " +
+                        "on c.challengeId=s.challenge.challengeId where s.walkie.userId = :userId")
                 .setParameter("userId", userId)
                 .getResultList();
 

--- a/src/main/java/com/whyranoid/walkie/service/ChallengeService.java
+++ b/src/main/java/com/whyranoid/walkie/service/ChallengeService.java
@@ -1,0 +1,21 @@
+package com.whyranoid.walkie.service;
+
+import com.whyranoid.walkie.domain.Challenge;
+import com.whyranoid.walkie.repository.ChallengeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeService{
+
+    private final ChallengeRepository challengeRepository;
+
+    public List<Challenge> getChallenges(Long userId, char challengeStatus) {
+        List<Challenge> result = challengeRepository.getChallenges(userId);
+        // 여기서 status에 따른 결과를 분리해야하는가?
+        return result;
+    }
+}


### PR DESCRIPTION
## 😎 작업 내용
- mysql과 인텔리제이 연결
- challenge service, repository, api 파일 생성해 mvc패턴 구성
- repository에서 mysql에 접근해 userId로 챌린지 목록 가져오는 기능 구현

## 🧐 변경된 내용
- 패키지가 아예 없다가 새로 생성하다보니 충돌이 날 수도 있을 것 같습니다.
- 현재 제가 만든 패키지 목록은 다음과 같습니다.
- api / config / controller / dto / repository / service

## 🥳 동작 화면
<img width="1367" alt="image" src="https://user-images.githubusercontent.com/39687846/235652576-f94b491a-d338-4dae-a1d1-4f6a7ec9248d.png">


## 🤯 이슈 번호
- 이슈 없음