### PR TITLE
안드 요청사항 우선반영

### DIFF
--- a/src/main/java/com/whyranoid/walkie/controller/WalkieController.java
+++ b/src/main/java/com/whyranoid/walkie/controller/WalkieController.java
@@ -31,4 +31,19 @@ public class WalkieController {
     public ResponseEntity<WalkieSignUpResponse> signUp(@RequestBody WalkieSignUpRequest walkieSignUpRequest) {
         return ResponseEntity.ok(walkieService.joinWalkie(walkieSignUpRequest));
     }
+
+    @Operation(description = "닉네임 중복 확인 -- 회원가입과 동일한 dto 사용")
+    @Parameters({
+            @Parameter(name = "userName", required = true, description = "닉네임", example = "군자동 불주먹")
+    })
+    @GetMapping("/signup/check")
+    public ResponseEntity<WalkieSignUpResponse> check(@RequestBody WalkieSignUpRequest walkieSignUpRequest) {
+        return ResponseEntity.ok(
+                WalkieSignUpResponse.builder()
+                        .hasDuplicatedName(
+                                walkieService.checkNameDuplication(walkieSignUpRequest.getUserName())
+                        )
+                        .build()
+        );
+    }
 }

--- a/src/main/java/com/whyranoid/walkie/dto/WalkieDto.java
+++ b/src/main/java/com/whyranoid/walkie/dto/WalkieDto.java
@@ -7,14 +7,14 @@ import lombok.Getter;
 @Getter
 public class WalkieDto {
 
-    private Long uid;
+    private Long walkieId;
     private String name;
     private String profileImg;
     private Character status;
 
     @QueryProjection
     public WalkieDto(Walkie walkie) {
-        this.uid = walkie.getUserId();
+        this.walkieId = walkie.getUserId();
         this.name = walkie.getUserName();
         this.profileImg = walkie.getProfileImg();
         this.status = walkie.getStatus();

--- a/src/main/java/com/whyranoid/walkie/dto/WalkingDto.java
+++ b/src/main/java/com/whyranoid/walkie/dto/WalkingDto.java
@@ -10,7 +10,7 @@ import java.util.Date;
 public class WalkingDto {
 
     @Schema(description = "요청 필수 파라미터 - 워키 아이디", example = "3")
-    private Long uid;
+    private Long walkieId;
 
     @Schema(description = "요청 필수 파라미터 - 운동 시작 시간", example = "2023-07-31T15:08:31.689Z")
     private Date startTime;
@@ -25,8 +25,8 @@ public class WalkingDto {
     private String authId;
 
     @Builder
-    public WalkingDto(Long uid, Date startTime, Long historyId, Character newStatus, String authId) {
-        this.uid = uid;
+    public WalkingDto(Long walkieId, Date startTime, Long historyId, Character newStatus, String authId) {
+        this.walkieId = walkieId;
         this.startTime = startTime;
         this.historyId = historyId;
         this.newStatus = newStatus;

--- a/src/main/java/com/whyranoid/walkie/dto/response/WalkieSignUpResponse.java
+++ b/src/main/java/com/whyranoid/walkie/dto/response/WalkieSignUpResponse.java
@@ -1,5 +1,6 @@
 package com.whyranoid.walkie.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,7 +8,15 @@ import lombok.Getter;
 @Builder
 public class WalkieSignUpResponse {
 
+    @Schema(description = "요청 후 중복 발생한 경우 true 반환")
     private boolean hasDuplicatedName;
-    private String accessToken;
-    private String refreshToken;
+    
+    @Schema(description = "가입된 사용자 고유 키 -- 사용자 조회 시 사용")
+    private Long walkieId;
+    
+    @Schema(description = "(검증용) 가입 요청했던 닉네임 반환")
+    private String walkieName;
+
+//    private String accessToken;
+//    private String refreshToken;
 }

--- a/src/main/java/com/whyranoid/walkie/service/WalkieService.java
+++ b/src/main/java/com/whyranoid/walkie/service/WalkieService.java
@@ -44,8 +44,8 @@ public class WalkieService {
 
         return WalkieSignUpResponse.builder()
                 .hasDuplicatedName(false)
-                .accessToken("아이디=" + walkie.getUserId())
-                .refreshToken("상태=" + walkie.getStatus())
+                .walkieId(walkie.getUserId())
+                .walkieName(walkie.getUserName())
                 .build();
     }
 


### PR DESCRIPTION
## 😎 작업 내용
- 회원가입 시 walkieId 반환하도록 응답 수정
- 닉네임 중복 확인 API 추가

## 🧐 변경된 내용
- 구글uid와 혼동하지 않도록 유저 키 변수명을 uid -> walkieId 통일

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- #16 