### PR TITLE
[api] 운동 시작, 실시간 좋아요

### DIFF
--- a/src/main/java/com/whyranoid/walkie/controller/WalkingController.java
+++ b/src/main/java/com/whyranoid/walkie/controller/WalkingController.java
@@ -42,4 +42,9 @@ public class WalkingController {
         return ResponseEntity.ok(walkingService.countWalkingLike(walkieId, authId));
     }
 
+    @Operation(description = "운동 종료 시 받은 좋아요 수와 좋아요 누른 사람 프로필 가져오기")
+    @GetMapping("/count-total")
+    public ResponseEntity<WalkingLikeDto> getTotalWalkingLike(@RequestParam Long walkieId, @RequestParam String authId) {
+        return ResponseEntity.ok(walkingService.getTotalWalkingLike(walkieId, authId));
+    }
 }

--- a/src/main/java/com/whyranoid/walkie/controller/WalkingController.java
+++ b/src/main/java/com/whyranoid/walkie/controller/WalkingController.java
@@ -8,9 +8,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "WalkingController")
@@ -32,6 +34,12 @@ public class WalkingController {
     @PostMapping("/send-like")
     public ResponseEntity<WalkingLikeDto> sendWalkingLike(@RequestBody WalkingLikeDto walkingLikeDto) {
         return ResponseEntity.ok(walkingService.sendWalkingLike(walkingLikeDto));
+    }
+
+    @Operation(description = "운동 중에 받은 좋아요 수 가져오기")
+    @GetMapping("/count-like")
+    public ResponseEntity<Long> countWalkingLike(@RequestParam Long walkieId, @RequestParam String authId) {
+        return ResponseEntity.ok(walkingService.countWalkingLike(walkieId, authId));
     }
 
 }

--- a/src/main/java/com/whyranoid/walkie/controller/WalkingController.java
+++ b/src/main/java/com/whyranoid/walkie/controller/WalkingController.java
@@ -4,9 +4,11 @@ import com.whyranoid.walkie.dto.WalkingDto;
 import com.whyranoid.walkie.dto.response.WalkingStartResponse;
 import com.whyranoid.walkie.service.WalkingService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,8 +22,9 @@ public class WalkingController {
     private final WalkingService walkingService;
 
     @Operation(description = "운동 시작 정보 저장")
-    @PutMapping("/start")
-    public WalkingStartResponse startWalking(@RequestBody WalkingDto walkingDto) {
-        return walkingService.startWalking(walkingDto);
+    @PostMapping("/start")
+    @ApiResponse(responseCode = "200", description = "OK -- 생성된 히스토리 아이디")
+    public ResponseEntity<Long> startWalking(@RequestBody WalkingDto walkingDto) {
+        return ResponseEntity.ok(walkingService.startWalking(walkingDto));
     }
 }

--- a/src/main/java/com/whyranoid/walkie/controller/WalkingController.java
+++ b/src/main/java/com/whyranoid/walkie/controller/WalkingController.java
@@ -1,7 +1,7 @@
 package com.whyranoid.walkie.controller;
 
 import com.whyranoid.walkie.dto.WalkingDto;
-import com.whyranoid.walkie.dto.response.WalkingStartResponse;
+import com.whyranoid.walkie.dto.WalkingLikeDto;
 import com.whyranoid.walkie.service.WalkingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -27,4 +27,11 @@ public class WalkingController {
     public ResponseEntity<Long> startWalking(@RequestBody WalkingDto walkingDto) {
         return ResponseEntity.ok(walkingService.startWalking(walkingDto));
     }
+
+    @Operation(description = "운동 중인 친구에게 좋아요 보내기")
+    @PostMapping("/send-like")
+    public ResponseEntity<WalkingLikeDto> sendWalkingLike(@RequestBody WalkingLikeDto walkingLikeDto) {
+        return ResponseEntity.ok(walkingService.sendWalkingLike(walkingLikeDto));
+    }
+
 }

--- a/src/main/java/com/whyranoid/walkie/domain/History.java
+++ b/src/main/java/com/whyranoid/walkie/domain/History.java
@@ -1,6 +1,7 @@
 package com.whyranoid.walkie.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,7 @@ import java.util.Date;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class History {
 
     @Id
@@ -19,32 +21,22 @@ public class History {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long historyId;
 
-    @NotNull
-    @Column(nullable = false)
     private Double distance;
 
     @NotNull
     @Column(name = "start_time", nullable = false)
     private Date startTime;
 
-    @NotNull
-    @Column(name = "end_time", nullable = false)
+    @Column(name = "end_time")
     private Date endTime;
 
-    @NotNull
-    @Column(name = "total_time", nullable = false)
+    @Column(name = "total_time")
     private Integer totalTime;
 
-    @NotNull
-    @Column(nullable = false)
     private Integer calorie;
 
-    @NotNull
-    @Column(nullable = false)
     private Integer step;
 
-    @NotNull
-    @Column(nullable = false)
     private String path;
 
     @ManyToOne

--- a/src/main/java/com/whyranoid/walkie/domain/WalkingLike.java
+++ b/src/main/java/com/whyranoid/walkie/domain/WalkingLike.java
@@ -1,0 +1,44 @@
+package com.whyranoid.walkie.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class WalkingLike {
+
+    @Id
+    @Column(name = "walking_like_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long walkingLikeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "history")
+    private History history;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "liker")
+    private Walkie liker;
+
+    @Builder
+    public WalkingLike(Long walkingLikeId, History history, Walkie liker) {
+        this.walkingLikeId = walkingLikeId;
+        this.history = history;
+        this.liker = liker;
+    }
+}

--- a/src/main/java/com/whyranoid/walkie/dto/WalkingDto.java
+++ b/src/main/java/com/whyranoid/walkie/dto/WalkingDto.java
@@ -21,7 +21,7 @@ public class WalkingDto {
     @Schema(description = "응답 파라미터 - 생성된 기록의 아이디", example = "15")
     private Long historyId;
 
-    @Schema(description = "요청 파라미터 - 갱신할 사용자 상태", example = "o")
+    @Schema(description = "요청 파라미터 - 갱신할 사용자 상태", example = "R")
     private Character newStatus;
 
 //    @Schema(description = "(임시) 요청 파라미터 - 인증 아이디|", example = "SUPER-SECRET-KEY")

--- a/src/main/java/com/whyranoid/walkie/dto/WalkingDto.java
+++ b/src/main/java/com/whyranoid/walkie/dto/WalkingDto.java
@@ -1,18 +1,21 @@
 package com.whyranoid.walkie.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WalkingDto {
 
-    @Schema(description = "요청 필수 파라미터 - 워키 아이디", example = "3")
+    @Schema(description = "요청 필수 파라미터 - 워키 아이디", requiredMode = Schema.RequiredMode.REQUIRED, example = "3")
     private Long walkieId;
 
-    @Schema(description = "요청 필수 파라미터 - 운동 시작 시간", example = "2023-07-31T15:08:31.689Z")
+    @Schema(description = "요청 필수 파라미터 - 운동 시작 시간", requiredMode = Schema.RequiredMode.REQUIRED, example = "2023-07-31T15:08:31.689Z")
     private Date startTime;
 
     @Schema(description = "응답 파라미터 - 생성된 기록의 아이디", example = "15")
@@ -21,15 +24,15 @@ public class WalkingDto {
     @Schema(description = "요청 파라미터 - 갱신할 사용자 상태", example = "o")
     private Character newStatus;
 
-    @Schema(description = "(임시) 요청 파라미터 - 인증 아이디|", example = "SUPER-SECRET-KEY")
-    private String authId;
+//    @Schema(description = "(임시) 요청 파라미터 - 인증 아이디|", example = "SUPER-SECRET-KEY")
+//    private String authId;
 
     @Builder
-    public WalkingDto(Long walkieId, Date startTime, Long historyId, Character newStatus, String authId) {
+    public WalkingDto(Long walkieId, Date startTime, Long historyId, Character newStatus, String authId, Long likerId) {
         this.walkieId = walkieId;
         this.startTime = startTime;
         this.historyId = historyId;
         this.newStatus = newStatus;
-        this.authId = authId;
+//        this.authId = authId;
     }
 }

--- a/src/main/java/com/whyranoid/walkie/dto/WalkingLikeDto.java
+++ b/src/main/java/com/whyranoid/walkie/dto/WalkingLikeDto.java
@@ -1,8 +1,8 @@
 package com.whyranoid.walkie.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,7 +16,7 @@ public class WalkingLikeDto {
     @Schema(description = "요청 필수 파라미터 - 좋아요 받은 유저의 워키 아이디", requiredMode = Schema.RequiredMode.REQUIRED, example = "1")
     private Long receiverId;
 
-    @Builder
+    @QueryProjection
     public WalkingLikeDto(Long senderId, Long receiverId) {
         this.senderId = senderId;
         this.receiverId = receiverId;

--- a/src/main/java/com/whyranoid/walkie/dto/WalkingLikeDto.java
+++ b/src/main/java/com/whyranoid/walkie/dto/WalkingLikeDto.java
@@ -3,8 +3,11 @@ package com.whyranoid.walkie.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,9 +19,22 @@ public class WalkingLikeDto {
     @Schema(description = "요청 필수 파라미터 - 좋아요 받은 유저의 워키 아이디", requiredMode = Schema.RequiredMode.REQUIRED, example = "1")
     private Long receiverId;
 
+    @Schema(description = "응답 파라미터 - 좋아요 누른 유저 수", example = "32")
+    private Long likerCount;
+
+    @Schema(description = "응답 파라미터 - 좋아요 누른 유저 5명의 프로필")
+    private List<WalkieDto> likerProfiles;
+
     @QueryProjection
     public WalkingLikeDto(Long senderId, Long receiverId) {
         this.senderId = senderId;
         this.receiverId = receiverId;
+    }
+
+    @Builder
+    public WalkingLikeDto(Long receiverId, Long likerCount, List<WalkieDto> likerProfiles) {
+        this.receiverId = receiverId;
+        this.likerCount = likerCount;
+        this.likerProfiles = likerProfiles;
     }
 }

--- a/src/main/java/com/whyranoid/walkie/dto/WalkingLikeDto.java
+++ b/src/main/java/com/whyranoid/walkie/dto/WalkingLikeDto.java
@@ -1,0 +1,24 @@
+package com.whyranoid.walkie.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WalkingLikeDto {
+
+    @Schema(description = "요청 필수 파라미터 - 좋아요 누른 유저의 워키 아이디", requiredMode = Schema.RequiredMode.REQUIRED, example = "3")
+    private Long senderId;
+
+    @Schema(description = "요청 필수 파라미터 - 좋아요 받은 유저의 워키 아이디", requiredMode = Schema.RequiredMode.REQUIRED, example = "1")
+    private Long receiverId;
+
+    @Builder
+    public WalkingLikeDto(Long senderId, Long receiverId) {
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+    }
+}

--- a/src/main/java/com/whyranoid/walkie/repository/HistoryRepository.java
+++ b/src/main/java/com/whyranoid/walkie/repository/HistoryRepository.java
@@ -1,7 +1,13 @@
 package com.whyranoid.walkie.repository;
 
 import com.whyranoid.walkie.domain.History;
+import com.whyranoid.walkie.domain.Walkie;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface HistoryRepository extends JpaRepository<History, Long> {
+
+    List<History> findFirst1ByUser(Walkie user, Sort sort);
 }

--- a/src/main/java/com/whyranoid/walkie/repository/WalkieRepository.java
+++ b/src/main/java/com/whyranoid/walkie/repository/WalkieRepository.java
@@ -10,4 +10,6 @@ public interface WalkieRepository extends JpaRepository<Walkie, Long> {
     Optional<Walkie> findByUserName(String userName);
 
     Optional<Walkie> findByAuthId(String authId);
+
+    Optional<Walkie> findByUserIdAndStatus(Long id, Character status);
 }

--- a/src/main/java/com/whyranoid/walkie/repository/WalkingLikeRepository.java
+++ b/src/main/java/com/whyranoid/walkie/repository/WalkingLikeRepository.java
@@ -1,0 +1,7 @@
+package com.whyranoid.walkie.repository;
+
+import com.whyranoid.walkie.domain.WalkingLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WalkingLikeRepository extends JpaRepository<WalkingLike, Long> {
+}

--- a/src/main/java/com/whyranoid/walkie/repository/WalkingLikeRepository.java
+++ b/src/main/java/com/whyranoid/walkie/repository/WalkingLikeRepository.java
@@ -1,7 +1,8 @@
 package com.whyranoid.walkie.repository;
 
 import com.whyranoid.walkie.domain.WalkingLike;
+import com.whyranoid.walkie.repository.querydsl.WalkingLikeRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface WalkingLikeRepository extends JpaRepository<WalkingLike, Long> {
+public interface WalkingLikeRepository extends JpaRepository<WalkingLike, Long>, WalkingLikeRepositoryCustom {
 }

--- a/src/main/java/com/whyranoid/walkie/repository/WalkingLikeRepository.java
+++ b/src/main/java/com/whyranoid/walkie/repository/WalkingLikeRepository.java
@@ -1,8 +1,14 @@
 package com.whyranoid.walkie.repository;
 
+import com.whyranoid.walkie.domain.History;
+import com.whyranoid.walkie.domain.Walkie;
 import com.whyranoid.walkie.domain.WalkingLike;
 import com.whyranoid.walkie.repository.querydsl.WalkingLikeRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface WalkingLikeRepository extends JpaRepository<WalkingLike, Long>, WalkingLikeRepositoryCustom {
+
+    List<WalkingLike> findByHistoryAndLiker(History history, Walkie sender);
 }

--- a/src/main/java/com/whyranoid/walkie/repository/WalkingLikeRepositoryImpl.java
+++ b/src/main/java/com/whyranoid/walkie/repository/WalkingLikeRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.whyranoid.walkie.repository;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.whyranoid.walkie.repository.querydsl.WalkingLikeRepositoryCustom;
+import lombok.RequiredArgsConstructor;
+
+import static com.whyranoid.walkie.domain.QHistory.history;
+import static com.whyranoid.walkie.domain.QWalkingLike.walkingLike;
+
+@RequiredArgsConstructor
+public class WalkingLikeRepositoryImpl implements WalkingLikeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Long findWalkingLikeCount(Long walkieId) {
+        return queryFactory
+                .select(walkingLike)
+                .from(walkingLike)
+                .where(walkingLike.history.historyId.eq(findCurrentHistory(walkieId))
+                        .and(walkingLike.liker.isNotNull()))
+                .stream().count();
+    }
+
+    public JPQLQuery<Long> findCurrentHistory(Long walkieId) {
+        return JPAExpressions
+                .select(history.historyId)
+                .from(history)
+                .where(history.user.userId.eq(walkieId))
+                .orderBy(history.historyId.desc())
+                .limit(1);
+    }
+}

--- a/src/main/java/com/whyranoid/walkie/repository/querydsl/WalkingLikeRepositoryCustom.java
+++ b/src/main/java/com/whyranoid/walkie/repository/querydsl/WalkingLikeRepositoryCustom.java
@@ -1,6 +1,10 @@
 package com.whyranoid.walkie.repository.querydsl;
 
+import com.whyranoid.walkie.dto.WalkingLikeDto;
+
 public interface WalkingLikeRepositoryCustom {
 
     Long findWalkingLikeCount(Long walkieId);
+
+    WalkingLikeDto findWalkingLikePeople(Long walkieId);
 }

--- a/src/main/java/com/whyranoid/walkie/repository/querydsl/WalkingLikeRepositoryCustom.java
+++ b/src/main/java/com/whyranoid/walkie/repository/querydsl/WalkingLikeRepositoryCustom.java
@@ -1,0 +1,6 @@
+package com.whyranoid.walkie.repository.querydsl;
+
+public interface WalkingLikeRepositoryCustom {
+
+    Long findWalkingLikeCount(Long walkieId);
+}

--- a/src/main/java/com/whyranoid/walkie/repository/querydsl/WalkingLikeRepositoryImpl.java
+++ b/src/main/java/com/whyranoid/walkie/repository/querydsl/WalkingLikeRepositoryImpl.java
@@ -3,8 +3,12 @@ package com.whyranoid.walkie.repository.querydsl;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.whyranoid.walkie.repository.querydsl.WalkingLikeRepositoryCustom;
+import com.whyranoid.walkie.dto.QWalkieDto;
+import com.whyranoid.walkie.dto.WalkieDto;
+import com.whyranoid.walkie.dto.WalkingLikeDto;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 import static com.whyranoid.walkie.domain.QHistory.history;
 import static com.whyranoid.walkie.domain.QWalkingLike.walkingLike;
@@ -24,6 +28,15 @@ public class WalkingLikeRepositoryImpl implements WalkingLikeRepositoryCustom {
                 .stream().count();
     }
 
+    @Override
+    public WalkingLikeDto findWalkingLikePeople(Long walkieId) {
+        return WalkingLikeDto.builder()
+                .receiverId(walkieId)
+                .likerCount(findWalkingLikeCount(walkieId))
+                .likerProfiles(findLikerList(walkieId))
+                .build();
+    }
+
     public JPQLQuery<Long> findCurrentHistory(Long walkieId) {
         return JPAExpressions
                 .select(history.historyId)
@@ -31,5 +44,13 @@ public class WalkingLikeRepositoryImpl implements WalkingLikeRepositoryCustom {
                 .where(history.user.userId.eq(walkieId))
                 .orderBy(history.historyId.desc())
                 .limit(1);
+    }
+
+    public List<WalkieDto> findLikerList(Long walkerId) {
+        return queryFactory
+                .select(new QWalkieDto(walkingLike.liker))
+                .from(walkingLike)
+                .where(walkingLike.history.historyId.eq(findCurrentHistory(walkerId)))
+                .fetch();
     }
 }

--- a/src/main/java/com/whyranoid/walkie/repository/querydsl/WalkingLikeRepositoryImpl.java
+++ b/src/main/java/com/whyranoid/walkie/repository/querydsl/WalkingLikeRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.whyranoid.walkie.repository;
+package com.whyranoid.walkie.repository.querydsl;
 
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;

--- a/src/main/java/com/whyranoid/walkie/service/WalkingService.java
+++ b/src/main/java/com/whyranoid/walkie/service/WalkingService.java
@@ -67,4 +67,12 @@ public class WalkingService {
 
         return walkingLikeRepository.findWalkingLikeCount(authWalkie.getUserId());
     }
+
+    public WalkingLikeDto getTotalWalkingLike(Long walkieId, String authId) {
+        Walkie authWalkie = walkieRepository.findByAuthId(authId).orElseThrow(EntityNotFoundException::new);
+
+        if (!authWalkie.getUserId().equals(walkieId)) throw new InvalidParameterException();
+
+        return walkingLikeRepository.findWalkingLikePeople(walkieId);
+    }
 }

--- a/src/main/java/com/whyranoid/walkie/service/WalkingService.java
+++ b/src/main/java/com/whyranoid/walkie/service/WalkingService.java
@@ -2,12 +2,14 @@ package com.whyranoid.walkie.service;
 
 import com.whyranoid.walkie.domain.History;
 import com.whyranoid.walkie.domain.Walkie;
+import com.whyranoid.walkie.domain.WalkingLike;
 import com.whyranoid.walkie.dto.WalkingDto;
-import com.whyranoid.walkie.dto.response.WalkieStatusChangeResponse;
-import com.whyranoid.walkie.dto.response.WalkingStartResponse;
+import com.whyranoid.walkie.dto.WalkingLikeDto;
 import com.whyranoid.walkie.repository.HistoryRepository;
 import com.whyranoid.walkie.repository.WalkieRepository;
+import com.whyranoid.walkie.repository.WalkingLikeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ public class WalkingService {
 
     private final WalkieRepository walkieRepository;
     private final HistoryRepository historyRepository;
+    private final WalkingLikeRepository walkingLikeRepository;
 
     public Long startWalking(WalkingDto walkingDto) {
         Walkie user = walkieRepository.findById(walkingDto.getWalkieId()).orElseThrow(EntityNotFoundException::new);
@@ -35,5 +38,21 @@ public class WalkingService {
 
         History history = historyRepository.save(input);
         return history.getHistoryId();
+    }
+
+    public WalkingLikeDto sendWalkingLike(WalkingLikeDto request) {
+        Walkie receiver = walkieRepository.findByUserIdAndStatus(request.getReceiverId(), 'o').orElseThrow(EntityNotFoundException::new);
+
+        Walkie sender = walkieRepository.findById(request.getSenderId()).orElseThrow(EntityNotFoundException::new);
+
+        History history = historyRepository.findFirst1ByUser(receiver, Sort.by("startTime").descending()).get(0);
+
+        WalkingLike input = WalkingLike.builder()
+                .history(history)
+                .liker(sender)
+                .build();
+
+        walkingLikeRepository.save(input);
+        return request;
     }
 }

--- a/src/main/java/com/whyranoid/walkie/service/WalkingService.java
+++ b/src/main/java/com/whyranoid/walkie/service/WalkingService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
+import java.security.InvalidParameterException;
 
 @Transactional
 @Service
@@ -46,6 +47,9 @@ public class WalkingService {
         Walkie sender = walkieRepository.findById(request.getSenderId()).orElseThrow(EntityNotFoundException::new);
 
         History history = historyRepository.findFirst1ByUser(receiver, Sort.by("startTime").descending()).get(0);
+
+        boolean already = !walkingLikeRepository.findByHistoryAndLiker(history, sender).isEmpty();
+        if (already) return request;
 
         WalkingLike input = WalkingLike.builder()
                 .history(history)

--- a/src/main/java/com/whyranoid/walkie/service/WalkingService.java
+++ b/src/main/java/com/whyranoid/walkie/service/WalkingService.java
@@ -55,4 +55,12 @@ public class WalkingService {
         walkingLikeRepository.save(input);
         return request;
     }
+
+    public Long countWalkingLike(Long walkieId, String authId) {
+        Walkie authWalkie = walkieRepository.findByAuthId(authId).orElseThrow(EntityNotFoundException::new);
+
+        if (!authWalkie.getUserId().equals(walkieId)) throw new InvalidParameterException();
+
+        return walkingLikeRepository.findWalkingLikeCount(authWalkie.getUserId());
+    }
 }


### PR DESCRIPTION
## 😎 작업 내용
- 운동 시작 API 수정 (서버 단에서 히스토리 생성)
- 내가 팔로우하는 유저 중 운동 중인 사람에게 좋아요 보내는 API 추가

## 🧐 변경된 내용
- Walkie 객체의 status를 R(운동 중), N(온라인), F(오프라인), B(차단) 중의 값으로 통일

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- 이슈 없음